### PR TITLE
Add .pruneKey()

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,29 @@ superagent
 );
 ```
 
+## .pruneKey(callback)
+
+This function takes a function which accepts a cache key object and returns a modified cache key object. This allows you to change what is used to track items in the cache (above-and-beyond what is provided by `.pruneQuery` and `.pruneHeader`).
+
+#### Arguments
+
+* callback: a function which takes a key object
+
+#### Example
+
+```javascript
+//the cache key can be any object but modifying the existing one
+//can allow you to do things like modify the URL used as the cache key
+superagent
+  .get(uri)
+  .set(options)
+  .pruneKey(key => ({...key, uri: key.uri.replace("https:", "http:")}))
+  .end(function (error, response){
+    // handle response
+  }
+);
+```
+
 ## .expiration(seconds)
 
 Use this function when you need to override your `cache`'s `defaultExpiration` property for a particular cache entry.

--- a/superagentCache.js
+++ b/superagentCache.js
@@ -49,6 +49,15 @@ module.exports = function(superagent, cache, defaults){
     }
 
     /**
+     * Modify the cache key before it's generated.
+     * @param {function} pruneKey
+     */
+    Request.prototype.pruneKey = function(pruneKey){
+      props.pruneKey = pruneKey;
+      return this;
+    }
+
+    /**
      * Execute some logic on superagent's http response object before caching and returning it
      * @param {function} prune
      */

--- a/test/server/api.js
+++ b/test/server/api.js
@@ -191,6 +191,21 @@ describe('superagentCache', function(){
       );
     });
 
+    it('.get() .pruneKey() .end() should query with all params but create a key without the indicated params', function (done) {
+      superagent
+        .get('localhost:3007/one')
+        .pruneKey(function (key) {
+          key.uri = 'localhost:3007/false';
+          return key;
+        })
+        .end(function (err, response, key){
+          expect(key.indexOf('/one')).toBe(-1);
+          expect(key.indexOf('/false')).toBeGreaterThan(-1);
+          done();
+        }
+      );
+    });
+
     it('.get() .query(object) .pruneQuery() .end() should query with all params but create a key without the indicated params', function (done) {
       superagent
         .get('localhost:3007/params')

--- a/utils.js
+++ b/utils.js
@@ -14,13 +14,17 @@ module.exports = {
       cleanParams = (cProps.pruneQuery) ? this.pruneObj(this.cloneObject(params), cProps.pruneQuery) : params;
       cleanOptions = (cProps.pruneHeader) ? this.pruneObj(this.cloneObject(options), cProps.pruneHeader, true) : options;
     }
-    return JSON.stringify({
+    var key = {
       nameSpace: agent.cache.nameSpace,
       method: req.method,
       uri: req.url,
       params: cleanParams || params || null,
       options: cleanOptions || options || null
-    });
+    };
+    if (cProps.pruneKey) {
+      key = cProps.pruneKey(key);
+    }
+    return JSON.stringify(key);
   },
 
   /**
@@ -180,6 +184,7 @@ module.exports = {
       prune: d.prune,
       pruneQuery: d.pruneQuery,
       pruneHeader: d.pruneHeader,
+      pruneKey: d.pruneKey,
       responseProp: d.responseProp,
       expiration: d.expiration,
       forceUpdate: d.forceUpdate,
@@ -201,6 +206,7 @@ module.exports = {
         .doQuery(curProps.doQuery)
         .pruneQuery(curProps.pruneQuery)
         .pruneHeader(curProps.pruneHeader)
+        .pruneKey(curProps.pruneKey)
         .prune(curProps.prune)
         .responseProp(curProps.responseProp)
         .expiration(curProps.expiration)


### PR DESCRIPTION
This adds a new function for modifying the key used to cache responses, above-and-beyond what `.pruneQuery` and `.pruneHeader` offer. This makes it possible to modify the URI in the key.

Test plan:
I ran `npm test` and it passed.